### PR TITLE
fixed params error in CCSpriteExtend:playAnimationForever()

### DIFF
--- a/framework/client/cocos2dx/CCSpriteExtend.lua
+++ b/framework/client/cocos2dx/CCSpriteExtend.lua
@@ -17,8 +17,8 @@ function CCSpriteExtend:playAnimationOnce(animation, removeWhenFinished, onCompl
     return transition.playAnimationOnce(self, animation, removeWhenFinished, onComplete, delay)
 end
 
-function CCSpriteExtend:playAnimationForever(target, animation, isRestoreOriginalFrame, delay)
-    return transition.playAnimationForever(self, target, animation, isRestoreOriginalFrame, delay)
+function CCSpriteExtend:playAnimationForever(animation, isRestoreOriginalFrame, delay)
+    return transition.playAnimationForever(self, animation, isRestoreOriginalFrame, delay)
 end
 
 function CCSpriteExtend:autoCleanup()

--- a/framework/shared/functions.lua
+++ b/framework/shared/functions.lua
@@ -322,11 +322,22 @@ Write a string to a file, or return FALSE on failure.
 
 @param string path
 @param string content
+@param string mode
 @return boolean
 
+### Note:
+The mode string can be any of the following:
+    "r": read mode
+    "w": write mode;
+    "a": append mode;
+    "r+": update mode, all previous data is preserved;
+    "w+": update mode, all previous data is erased; (the default);
+    "a+": append update mode, previous data is preserved, writing is only allowed at the end of file.
+
 ]]
-function io.writefile(path, content)
-    local file = io.open(path, "w+")
+function io.writefile(path, content, mode)
+    mode = mode or "w+"
+    local file = io.open(path, mode)
     if file then
         if file:write(content) == nil then return false end
         io.close(file)


### PR DESCRIPTION
added  param "mode" in io.write()  to control file open mode
