### PR TITLE
Fix the "Bad substitution" warning

### DIFF
--- a/bin/compile_luabinding.sh
+++ b/bin/compile_luabinding.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 php $DIR/lib/compile_luabinding.php $*

--- a/bin/compile_scripts.sh
+++ b/bin/compile_scripts.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 php "$DIR/lib/compile_scripts.php" $*

--- a/bin/create_project.sh
+++ b/bin/create_project.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TEMPLATE_ROOT=`dirname "$DIR"`/template
 php "$DIR/lib/create_project.php" -t "$TEMPLATE_ROOT/PROJECT_TEMPLATE_01" $*

--- a/bin/make_api_doc.sh
+++ b/bin/make_api_doc.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DEST_DIR="$DIR/../doc/api"
 if [ -d "$DEST_DIR" ]; then

--- a/bin/make_dist_zip.sh
+++ b/bin/make_dist_zip.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$DIR/../../"
 DEST_DIR=`pwd`

--- a/bin/make_framework_package.sh
+++ b/bin/make_framework_package.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$DIR/../"
 "$DIR/compile_scripts.sh" -zip -x framework.server -p framework framework lib/framework_precompiled/framework_precompiled

--- a/lib/cocos2dx_extensions_luabinding/build.sh
+++ b/lib/cocos2dx_extensions_luabinding/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$DIR"
 OUTPUT_DIR="$DIR"

--- a/lib/cocos2dx_extra/build_luabinding/build.sh
+++ b/lib/cocos2dx_extra/build_luabinding/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$DIR"
 OUTPUT_DIR="$DIR"/../extra/luabinding

--- a/lib/luajit2/build_android.sh
+++ b/lib/luajit2/build_android.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SRCDIR=$DIR/LuaJit-2.0.1
 DESTDIR=$DIR/proj.android

--- a/lib/luajit2/build_ios.sh
+++ b/lib/luajit2/build_ios.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SRCDIR=$DIR/LuaJit-2.0.1
 DESTDIR=$DIR/proj.ios

--- a/lib/luajit2/build_mac.sh
+++ b/lib/luajit2/build_mac.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SRCDIR=$DIR/LuaJit-2.0.1
 DESTDIR=$DIR/proj.mac

--- a/sample/Benchmark/proj.android/build_native.sh
+++ b/sample/Benchmark/proj.android/build_native.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 APPNAME="benchmark"
 

--- a/sample/Benchmark/proj.android/clean.sh
+++ b/sample/Benchmark/proj.android/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 rm -fr $DIR/obj/*
 rm -fr $DIR/libs/armeabi/*.so

--- a/sample/Benchmark/run_simulator_mac.sh
+++ b/sample/Benchmark/run_simulator_mac.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$DIR"
 "$DIR/../../simulator/bin/mac/LuaHostMac.app/Contents/MacOS/LuaHostMac" -workdir "$DIR" -file scripts/main.lua -size 800x480

--- a/sample/CoinFlip/proj.android/build_native.sh
+++ b/sample/CoinFlip/proj.android/build_native.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 APPNAME="coinflip"
 

--- a/sample/CoinFlip/proj.android/clean.sh
+++ b/sample/CoinFlip/proj.android/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 rm -fr $DIR/obj/*
 rm -fr $DIR/libs/armeabi/*.so

--- a/sample/CoinFlip/run_simulator_mac.sh
+++ b/sample/CoinFlip/run_simulator_mac.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$DIR"
 "$DIR/../../simulator/bin/mac/LuaHostMac.app/Contents/MacOS/LuaHostMac" -workdir "$DIR" -file scripts/main.lua -size 480x800

--- a/sample/network/proj.android/build_native.sh
+++ b/sample/network/proj.android/build_native.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 APP_ROOT="$DIR/.."

--- a/sample/network/proj.android/clean.sh
+++ b/sample/network/proj.android/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 rm -fr $DIR/obj/*
 rm -fr $DIR/libs/armeabi/*.so

--- a/template/PROJECT_TEMPLATE_01/proj.android/build_native.sh
+++ b/template/PROJECT_TEMPLATE_01/proj.android/build_native.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 APP_ROOT="$DIR/.."

--- a/template/PROJECT_TEMPLATE_01/proj.android/clean.sh
+++ b/template/PROJECT_TEMPLATE_01/proj.android/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 rm -fr $DIR/obj/*
 rm -fr $DIR/libs/armeabi/*.so


### PR DESCRIPTION
Since most scripts use the substitude techniques to get DIR
variable, it do need bash instead of sh.

需要用bash来执行DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
不能直接用sh
