### PR TITLE
stop all actions before remove node

### DIFF
--- a/lib/cocos2d-x/extensions/CCArmature/display/CCDisplayManager.cpp
+++ b/lib/cocos2d-x/extensions/CCArmature/display/CCDisplayManager.cpp
@@ -138,6 +138,7 @@ void CCDisplayManager::changeDisplayByIndex(int index, bool force)
     {
         if(m_pDisplayRenderNode)
         {
+            m_pDisplayRenderNode->stopAllActions();
             m_pDisplayRenderNode->removeFromParentAndCleanup(true);
             setCurrentDecorativeDisplay(NULL);
         }


### PR DESCRIPTION
在移除节点前需要尝试移除节点上的动作，不然只要是还有动作未完成，Player就会崩溃。
