### PR TITLE
fix bug about suffix(.lua)

### DIFF
--- a/lib/cocos2d-x/scripting/lua/cocos2dx_support/Cocos2dxLuaLoader.cpp
+++ b/lib/cocos2d-x/scripting/lua/cocos2dx_support/Cocos2dxLuaLoader.cpp
@@ -34,10 +34,16 @@ extern "C"
     int cocos2dx_lua_loader(lua_State *L)
     {
         std::string filename(luaL_checkstring(L, 1));
-        size_t pos = filename.rfind(".lua");
+        
+        const std::string SUFFIX_LUA = ".lua";
+        size_t pos = filename.rfind(SUFFIX_LUA);
         if (pos != std::string::npos)
         {
-            filename = filename.substr(0, pos);
+            if( pos == (filename.length() - SUFFIX_LUA.length()) )
+            {
+                filename = filename.substr(0, pos);
+            }
+            
         }
 
         pos = filename.find_first_of(".");


### PR DESCRIPTION
[BUG日志反馈](https://groups.google.com/forum/#!topic/quick-x/fq5Fcu29ll0)

```
11-28 20:40:54.630: D/cocos2d-x debug info(26147): [0.0572] [INFO] # device.directorySeparator    = /
11-28 20:40:54.630: D/cocos2d-x debug info(26147): [0.0572] [INFO] # device.pathSeparator         = :
11-28 20:40:54.630: D/cocos2d-x debug info(26147): [0.0572] [INFO] #
11-28 20:40:54.640: D/cocos2d-x debug info(26147): [0.0662] [INFO] # CONFIG_SCREEN_AUTOSCALE      = FIXED_WIDTH
11-28 20:40:54.640: D/cocos2d-x debug info(26147): [0.0665] [INFO] # CONFIG_SCREEN_WIDTH          = 960.00
11-28 20:40:54.640: D/cocos2d-x debug info(26147): [0.0666] [INFO] # CONFIG_SCREEN_HEIGHT         = 1600.00
11-28 20:40:54.640: D/cocos2d-x debug info(26147): [0.0668] [INFO] # display.widthInPixels        = 480.00
11-28 20:40:54.640: D/cocos2d-x debug info(26147): [0.0669] [INFO] # display.heightInPixels       = 800.00
11-28 20:40:54.640: D/cocos2d-x debug info(26147): [0.0670] [INFO] # display.contentScaleFactor   = 0.50
11-28 20:40:54.640: D/cocos2d-x debug info(26147): [0.0671] [INFO] # display.width                = 960.00
11-28 20:40:54.640: D/cocos2d-x debug info(26147): [0.0673] [INFO] # display.height               = 1600.00
11-28 20:40:54.640: D/cocos2d-x debug info(26147): [0.0676] [INFO] # display.cx                   = 480.00
11-28 20:40:54.640: D/cocos2d-x debug info(26147): [0.0679] [INFO] # display.cy                   = 800.00
11-28 20:40:54.640: D/cocos2d-x debug info(26147): [0.0681] [INFO] # display.left                 = 0.00
11-28 20:40:54.640: D/cocos2d-x debug info(26147): [0.0683] [INFO] # display.right                = 960.00
11-28 20:40:54.640: D/cocos2d-x debug info(26147): [0.0685] [INFO] # display.top                  = 1600.00
11-28 20:40:54.640: D/cocos2d-x debug info(26147): [0.0687] [INFO] # display.bottom               = 0.00
11-28 20:40:54.640: D/cocos2d-x debug info(26147): [0.0690] [INFO] # display.c_left               = -480.00
11-28 20:40:54.640: D/cocos2d-x debug info(26147): [0.0692] [INFO] # display.c_right              = 480.00
11-28 20:40:54.640: D/cocos2d-x debug info(26147): [0.0694] [INFO] # display.c_top                = 800.00
11-28 20:40:54.640: D/cocos2d-x debug info(26147): [0.0695] [INFO] # display.c_bottom             = -800.00
11-28 20:40:54.640: D/cocos2d-x debug info(26147): [0.0697] [INFO] #
11-28 20:40:54.650: D/cocos2d-x debug info(26147): can not get file data of framework.lua
```
-  framework.luaj
-  framework.luaoc

这2个文件在被这个类处理的时候，按照之前的，会找到`.lua`后截断，然后文件被处理为framework.lua

现在增加`.lua`是否是文件末尾的判断

```
const std::string SUFFIX_LUA = ".lua";
size_t pos = filename.rfind(SUFFIX_LUA);
if( pos == (filename.length() - SUFFIX_LUA.length()) )
```
