### PR TITLE
Enable Stencil buffer on Mac, for CCClippingNode.

### DIFF
--- a/lib/cocos2d-x/cocos2dx/platform/mac/EAGLView.mm
+++ b/lib/cocos2d-x/cocos2dx/platform/mac/EAGLView.mm
@@ -74,6 +74,7 @@ static EAGLView *view;
 //		NSOpenGLPFANoRecovery,
 		NSOpenGLPFADoubleBuffer,
 		NSOpenGLPFADepthSize, 24,
+		NSOpenGLPFAStencilSize, 8,
 		0
     };
     frameRect.size = [self makeSizeEven:frameRect.size];


### PR DESCRIPTION
Enable Stencil buffer on Mac, for CCClippingNode.
