### PR TITLE
Update PacketBuffer.lua

### DIFF
--- a/samples/luasocket/scripts/net/PacketBuffer.lua
+++ b/samples/luasocket/scripts/net/PacketBuffer.lua
@@ -9,7 +9,7 @@ Creation: 2013-11-14
 local PacketBuffer = class("PacketBuffer")
 local Protocol = require("net.Protocol")
 
-PacketBuffer.ENDIAN = cc.utils.ByteArrayVarint.ENDIAN_LITTLE
+PacketBuffer.ENDIAN = cc.utils.ByteArrayVarint.ENDIAN_BIG
 
 PacketBuffer.MASK1 = 0x86
 PacketBuffer.MASK2 = 0x7b


### PR DESCRIPTION
是否默认为大端字节序好些？网络传输一般采用大端序啊，默认为小的调了半天。。。
