### PR TITLE
fix bug of "javaClassName" in sample project "luajavabridge"

### DIFF
--- a/samples/luajavabridge/scripts/scenes/MainScene.lua
+++ b/samples/luajavabridge/scripts/scenes/MainScene.lua
@@ -12,7 +12,7 @@ function MainScene:ctor()
         align = ui.TEXT_ALIGN_CENTER,
         listener = function()
             -- call Java method
-            local javaClassName = "com.quick_x.sample.luajavabridge.Luajavabridge"
+            local javaClassName = "com/quick_x/sample/luajavabridge/Luajavabridge"
             local javaMethodName = "showAlertDialog"
             local javaParams = {
                 "How are you ?",


### PR DESCRIPTION
luajavabridge示例里有个小问题，javaClassName字串是用点号分隔的，但JNI的标准是“/”号。很多机子两种都支持不会出错，但有部分机子只支持JNI标准在运行时会出错闪退。从通用性出发，这个例子里用“/”比较好一些。
