### PR TITLE
Update display.lua

### DIFF
--- a/framework/display.lua
+++ b/framework/display.lua
@@ -1284,7 +1284,7 @@ function display.printscreen(node, args)
 	if sp then
 		local texture = canvas:getSprite():getTexture()
 		if filters then
-			sp = display.newFSprite(texture, filters, filterParams)
+			sp = display.newFilteredSprite(texture, filters, filterParams)
 		else
 			sp = display.newSprite(texture)
 		end


### PR DESCRIPTION
修复display.printscreen方法中调用不存在的类newFSprite的报错
