### PR TITLE
The Lua Class is not a meta table now. It is a normal table, has a key n...

### DIFF
--- a/lib/cocos2d-x/scripting/lua/tolua/tolua_is.c
+++ b/lib/cocos2d-x/scripting/lua/tolua/tolua_is.c
@@ -120,7 +120,24 @@ static  int lua_isusertable (lua_State* L, int lo, const char* type)
 {
     int r = 0;
     if (lo < 0) lo = lua_gettop(L)+lo+1;
-    lua_pushvalue(L,lo);
+    lua_pushvalue(L, lo);                   // stack: ... table
+
+    // A class table must use metatable to get it's type now. 2014.6.5 by SunLightJuly
+    if (lua_istable(L, -1)) {
+        lua_pushliteral(L, ".isclass");
+        lua_rawget(L, -2);                  // stack: ... table class_flag
+        if (!lua_isnil(L, -1)) {
+            lua_pop(L, 1);                  // stack: ... table
+            if (lua_getmetatable(L, -1)) {
+                                            // stack: ... table mt
+                lua_remove(L, -2);          // stack: ... mt
+            }
+        }
+        else {
+            lua_pop(L, 1);                  // stack: ... table
+        }
+    }
+    
     lua_rawget(L,LUA_REGISTRYINDEX);  /* get registry[t] */
     if (lua_isstring(L,-1))
     {

--- a/lib/luabinding/Cocos2d.tolua
+++ b/lib/luabinding/Cocos2d.tolua
@@ -2,18 +2,3 @@
 $pfile "cocos2dx/Cocos2d.tolua"
 $pfile "CocosDenshion/SimpleAudioEngine.tolua"
 $pfile "extensions/cocos-ext.tolua"
-
-$[
-
-function tolua.getcfunction(cls, name)
-    local cname = name .. "_C__"
-    return cls[cname]
-end
-
-function tolua.resetcfunction(cls, name)
-    local cname = name .. "_C__"
-    local f = cls[cname]
-    if f then cls[name] = f end
-end
-
-$]


### PR DESCRIPTION
提供了tolua.getbackup接口获取在Lua被覆盖的c函数。注意如果没有被覆盖的话，将会返回nil。具体可见Commit时的注释。
使用示例：

function CCNode:setPosition(x, y)
    print("----CCNode:setPosition("..x..","..y..")")
    local func = tolua.getbackup(CCNode, "setPosition")
    if func then return func(self, x, y) end
end
