### PR TITLE
修复player下调用CCImage::saveToFile 导致断言崩溃问题, CCRenderTexture可以保存到文件

### DIFF
--- a/lib/cocos2d-x/cocos2dx/platform/mac/CCImage.mm
+++ b/lib/cocos2d-x/cocos2dx/platform/mac/CCImage.mm
@@ -924,10 +924,95 @@ bool CCImage::initWithString(
     return true;
 }
 
+void CGImageWriteToFile(CGImageRef image, NSString *path, const CFStringRef type) {
+    CFURLRef url = (CFURLRef)[NSURL fileURLWithPath:path];
+    CGImageDestinationRef destination = CGImageDestinationCreateWithURL(url, type, 1, NULL);
+    CGImageDestinationAddImage(destination, image, nil);
+    
+    if (!CGImageDestinationFinalize(destination)) {
+        NSLog(@"Failed to write image to %@", path);
+    }
+    
+    CFRelease(destination);
+}
+
 bool CCImage::saveToFile(const char *pszFilePath, bool bIsToRGB)
 {
-	assert(false);
-	return false;
+    bool saveToPNG = false;
+    bool needToCopyPixels = false;
+    std::string filePath(pszFilePath);
+    if (std::string::npos != filePath.find(".png"))
+    {
+        saveToPNG = true;
+    }
+
+    int bitsPerComponent = 8;
+    int bitsPerPixel = m_bHasAlpha ? 32 : 24;
+    if ((! saveToPNG) || bIsToRGB)
+    {
+        bitsPerPixel = 24;
+    }
+
+    int bytesPerRow    = (bitsPerPixel/8) * m_nWidth;
+    int myDataLength = bytesPerRow * m_nHeight;
+
+    unsigned char *pixels    = m_pData;
+
+    // The data has alpha channel, and want to save it with an RGB png file,
+    // or want to save as jpg,  remove the alpha channel.
+    if ((saveToPNG && m_bHasAlpha && bIsToRGB)
+       || (! saveToPNG))
+    {
+        pixels = new unsigned char[myDataLength];
+
+        for (int i = 0; i < m_nHeight; ++i)
+        {
+            for (int j = 0; j < m_nWidth; ++j)
+            {
+                pixels[(i * m_nWidth + j) * 3] = m_pData[(i * m_nWidth + j) * 4];
+                pixels[(i * m_nWidth + j) * 3 + 1] = m_pData[(i * m_nWidth + j) * 4 + 1];
+                pixels[(i * m_nWidth + j) * 3 + 2] = m_pData[(i * m_nWidth + j) * 4 + 2];
+            }
+        }
+
+        needToCopyPixels = true;
+    }
+
+    // make data provider with data.
+    CGBitmapInfo bitmapInfo = kCGBitmapByteOrderDefault;
+    if (saveToPNG && m_bHasAlpha && (! bIsToRGB))
+    {
+        bitmapInfo |= kCGImageAlphaPremultipliedLast;
+    }
+    CGDataProviderRef provider        = CGDataProviderCreateWithData(NULL, pixels, myDataLength, NULL);
+    CGColorSpaceRef colorSpaceRef    = CGColorSpaceCreateDeviceRGB();
+    CGImageRef iref                    = CGImageCreate(m_nWidth, m_nHeight,
+                                                        bitsPerComponent, bitsPerPixel, bytesPerRow,
+                                                        colorSpaceRef, bitmapInfo, provider,
+                                                        NULL, false,
+                                                        kCGRenderingIntentDefault);
+
+
+    if (saveToPNG)
+    {
+        CGImageWriteToFile(iref,[NSString stringWithUTF8String:pszFilePath], kUTTypePNG);
+    }
+    else
+    {
+        CGImageWriteToFile(iref,[NSString stringWithUTF8String:pszFilePath], kUTTypeJPEG);
+    }
+
+    CGImageRelease(iref);
+    CGColorSpaceRelease(colorSpaceRef);
+    CGDataProviderRelease(provider);
+    
+    
+    if (needToCopyPixels)
+    {
+        delete [] pixels;
+    }
+
+    return true;
 }
 
 


### PR DESCRIPTION
player下例题中的RenderTextureTest点击SaveImage会崩溃,原因是因为mac/CCImage.mm的saveToFile没有实现,亲测可用.
