### PR TITLE
Tolua bug fix

### DIFF
--- a/lib/cocos2d-x/scripting/lua/tolua/tolua_event.c
+++ b/lib/cocos2d-x/scripting/lua/tolua/tolua_event.c
@@ -136,31 +136,29 @@ static int class_table_get_index (lua_State* L)
 {
     // stack:  obj key ... obj
     
-    while (lua_getmetatable(L,-1))
-    {   /* stack: obj key obj mt */
+    while (lua_getmetatable(L,-1)) {   /* stack: obj key obj mt */
         lua_remove(L,-2);                      /* stack: ... mt */
-        {
-            lua_pushvalue(L,2);                    /* stack: ... mt key */
-            lua_rawget(L,-2);                      /* stack: ... mt value */
-            if (!lua_isnil(L,-1))
-                return 1;
-            else
-                lua_pop(L,1);
+        
+        lua_pushvalue(L,2);                    /* stack: ... mt key */
+        lua_rawget(L,-2);                      /* stack: ... mt value */
+        if (!lua_isnil(L,-1)) {
+            return 1;
+        } else {
+            lua_pop(L,1);
         }
+        
         /* try C/C++ variable */
         lua_pushstring(L,".get");
         lua_rawget(L,-2);                   /* stack: obj key ... mt tget */
-        if (lua_istable(L,-1))
-        {
+        if (lua_istable(L,-1)) {
             lua_pushvalue(L,2);  /* stack: obj key ... mt tget key */
             lua_rawget(L,-2);    /* stack: obj key ... mt tget value */
-            if (lua_iscfunction(L,-1))
-            {
+            if (lua_iscfunction(L,-1)) {
                 lua_call(L,0,1);
                 return 1;
-            }
-            else if (lua_istable(L,-1))
+            } else if (lua_istable(L,-1)) {
                 return 1;
+            }
             lua_pop(L, 2);
         }
     }
@@ -387,12 +385,10 @@ static int class_newindex_event (lua_State* L)
         lua_getmetatable(L,1);  /* stack: t k v mt */
         lua_pushstring(L,".set");
         lua_rawget(L,-2);       /* stack: t k v mt tset */
-        if (lua_istable(L,-1))
-        {
+        if (lua_istable(L,-1)) {
             lua_pushvalue(L,2);  /* stack: t k v mt tset k */
             lua_rawget(L,-2);
-            if (lua_iscfunction(L,-1))  /* ... func */
-            {
+            if (lua_iscfunction(L,-1)) {  /* ... func */
                 lua_pushvalue(L,1); /* ... func t */
                 lua_pushvalue(L,3); /* ... func t v */
                 lua_call(L,2,0);
@@ -413,8 +409,7 @@ static int class_call_event(lua_State* L) {
 
     if (lua_istable(L, 1)) {
         //class is not a metatable now, so must get it's metatable to access ".call" function. 2014.6.5 by SunLightJuly
-        if (lua_getmetatable(L, 1))
-        {
+        if (lua_getmetatable(L, 1)) {
             lua_replace(L, 1);
             lua_pushstring(L, ".call");
             lua_rawget(L, 1);
@@ -424,10 +419,9 @@ static int class_call_event(lua_State* L) {
                 lua_call(L, lua_gettop(L)-1, 1);
                 
                 return 1;
-            };
+            }
         }
-        
-    };
+    }
     tolua_error(L,"Attempt to call a non-callable object.",NULL);
     return 0;
 };

--- a/lib/cocos2d-x/scripting/lua/tolua/tolua_is.c
+++ b/lib/cocos2d-x/scripting/lua/tolua/tolua_is.c
@@ -128,12 +128,10 @@ static  int lua_isusertable (lua_State* L, int lo, const char* type)
         lua_rawget(L, -2);                  // stack: ... table class_flag
         if (!lua_isnil(L, -1)) {
             lua_pop(L, 1);                  // stack: ... table
-            if (lua_getmetatable(L, -1)) {
-                                            // stack: ... table mt
+            if (lua_getmetatable(L, -1)) {  // stack: ... table mt
                 lua_remove(L, -2);          // stack: ... mt
             }
-        }
-        else {
+        } else {
             lua_pop(L, 1);                  // stack: ... table
         }
     }

--- a/lib/cocos2d-x/scripting/lua/tolua/tolua_map.c
+++ b/lib/cocos2d-x/scripting/lua/tolua/tolua_map.c
@@ -313,8 +313,7 @@ static int tolua_bnd_getcfunction(lua_State* L) {
         if (!lua_isnil(L, -1)) {
             lua_pushvalue(L, 2);    /* stack: class key mt mt[".backup"] key */
             lua_rawget(L, -2);
-            if (!lua_isnil(L, -1)) {
-                // key had been found
+            if (!lua_isnil(L, -1)) { // key had been found
                 return 1;
             }
             lua_pop(L, 1);
@@ -343,10 +342,8 @@ TOLUA_API void tolua_open (lua_State* L)
         lua_pushstring(L,"tolua_opened");
         lua_pushboolean(L,1);
         lua_rawset(L,LUA_REGISTRYINDEX);
-
         
-        /** create value root table
-         */
+        // create value root table
         lua_pushstring(L, TOLUA_VALUE_ROOT);
         lua_newtable(L);
         lua_rawset(L, LUA_REGISTRYINDEX);

--- a/lib/cocos2d-x/scripting/lua/tolua/tolua_push.c
+++ b/lib/cocos2d-x/scripting/lua/tolua/tolua_push.c
@@ -48,7 +48,7 @@ TOLUA_API void tolua_pushuserdata (lua_State* L, void* value)
         lua_pushlightuserdata(L,value);
 }
 
-void tolua_pushusertype_internal (lua_State* L, void* value, const char* type, int addtoroot)
+void tolua_pushusertype_internal (lua_State* L, void* value, const char* type, int addToRoot)
 {
     if (value == NULL)
         lua_pushnil(L);
@@ -66,10 +66,10 @@ void tolua_pushusertype_internal (lua_State* L, void* value, const char* type, i
             lua_pushstring(L, "tolua_ubox");
             lua_rawget(L, LUA_REGISTRYINDEX);
         };
-
+        
         lua_pushlightuserdata(L,value);                             /* stack: mt ubox key<value> */
         lua_rawget(L,-2);                                           /* stack: mt ubox ubox[value] */
-
+        
         if (lua_isnil(L,-1))
         {
             lua_pop(L,1);                                           /* stack: mt ubox */
@@ -82,10 +82,10 @@ void tolua_pushusertype_internal (lua_State* L, void* value, const char* type, i
             /*luaL_getmetatable(L,type);*/
             lua_pushvalue(L, -2);                                   /* stack: mt newud mt */
             lua_setmetatable(L,-2);                      /* update mt, stack: mt newud */
-
+            
 #ifdef LUA_VERSION_NUM
-            lua_pushvalue(L, TOLUA_NOPEER);                         /* stack: mt newud peer */
-            lua_setfenv(L, -2);                                     /* stack: mt newud */
+            lua_pushvalue(L, TOLUA_NOPEER);             /* stack: mt newud peer */
+            lua_setfenv(L, -2);                         /* stack: mt newud */
 #endif
         }
         else
@@ -115,13 +115,13 @@ void tolua_pushusertype_internal (lua_State* L, void* value, const char* type, i
             lua_pop(L,3);                          /* stack: mt ubox[u] */
         }
         lua_remove(L, -2);    /* stack: ubox[u]*/
-
-        if (addtoroot)
+        
+        if (0 != addToRoot)
         {
             lua_pushvalue(L, -1);
             tolua_add_value_to_root(L, value);
         }
-    }
+    } 
 }
 
 TOLUA_API void tolua_pushusertype (lua_State* L, void* value, const char* type)
@@ -134,25 +134,28 @@ TOLUA_API void tolua_pushusertype_and_addtoroot (lua_State* L, void* value, cons
     tolua_pushusertype_internal(L, value, type, 1);
 }
 
-TOLUA_API void tolua_add_value_to_root (lua_State* L, void* ptr)
+TOLUA_API void tolua_add_value_to_root(lua_State* L, void* ptr)
 {
+    
     lua_pushstring(L, TOLUA_VALUE_ROOT);
     lua_rawget(L, LUA_REGISTRYINDEX);                               /* stack: value root */
     lua_insert(L, -2);                                              /* stack: root value */
     lua_pushlightuserdata(L, ptr);                                  /* stack: root value ptr */
     lua_insert(L, -2);                                              /* stack: root ptr value */
-    lua_rawset(L, -3);                           /* root[ptr] = value, stack: root */
+    lua_rawset(L, -3);                                              /* root[ptr] = value, stack: root */
     lua_pop(L, 1);                                                  /* stack: - */
 }
+
 
 TOLUA_API void tolua_remove_value_from_root (lua_State* L, void* ptr)
 {
     lua_pushstring(L, TOLUA_VALUE_ROOT);
     lua_rawget(L, LUA_REGISTRYINDEX);                               /* stack: root */
     lua_pushlightuserdata(L, ptr);                                  /* stack: root ptr */
+    
     lua_pushnil(L);                                                 /* stack: root ptr nil */
-    lua_rawset(L, -3);                             /* root[ptr] = nil, stack: root */
-    lua_pop(L, 1);                                                  /* stack: - */
+    lua_rawset(L, -3);                                              /* root[ptr] = nil, stack: root */
+    lua_pop(L, 1);
 }
 
 TOLUA_API void tolua_pushusertype_and_takeownership (lua_State* L, void* value, const char* type)


### PR DESCRIPTION
在tolua_beginmodule这个函数中，由于现在C++类表与它的metatable表已经分开，所以之前的代码如果在tolua_cclass中定义的类名与它的metatable名不一致，会造成metatable找不到，导致后续的域成员无法加入到metatable中。现已经修改这一问题。

其他修改的地方只是顺便将代码风格标准化了一下，没有其他影响。
