### PR TITLE
基类WebSocket在析构函数中会调用WebSocket::Delegate::onClose，

### DIFF
--- a/lib/cocos2d-x/scripting/lua/cocos2dx_support/Lua_web_socket.cpp
+++ b/lib/cocos2d-x/scripting/lua/cocos2dx_support/Lua_web_socket.cpp
@@ -52,7 +52,7 @@ static int SendBinaryMessageToLua(int nHandler,const unsigned char* pTable,int n
     return nRet;
 }
 
-class LuaWebSocket: public WebSocket,public WebSocket::Delegate
+class LuaWebSocket: public WebSocket::Delegate, public WebSocket
 {
 public:
     virtual ~LuaWebSocket()


### PR DESCRIPTION
基类WebSocket在析构函数中会调用WebSocket::Delegate::onClose，
在以前的写法下，
第二基类WebSocket::Delegate先于第一基类WebSocket析构，导致非法访问。
