### PR TITLE
修复imageView重复缩放

### DIFF
--- a/framework/cc/ui/UIImage.lua
+++ b/framework/cc/ui/UIImage.lua
@@ -27,14 +27,6 @@ function UIImage:setLayoutSize(width, height)
 
     if self.isScale9_ then
         self:setContentSize(cc.size(width, height))
-    else
-        local boundingSize = self:getBoundingBox().size
-        local sx = width / (boundingSize.width / self:getScaleX())
-        local sy = height / (boundingSize.height / self:getScaleY())
-        if sx > 0 and sy > 0 then
-            self:setScaleX(sx)
-            self:setScaleY(sy)
-        end
     end
 
     if self.layout_ then


### PR DESCRIPTION
当scaleX,scaleY为1，图片自定义大小与原始大小不同时，图片会进行两次缩小或放大

line 25~26获取的大小已经是自定义尺寸
