### PR TITLE
CCNode添加接口递归设置CascadeOpacityEnabled

### DIFF
--- a/framework/cocos2dx/NodeEx.lua
+++ b/framework/cocos2dx/NodeEx.lua
@@ -168,3 +168,24 @@ end
 function Node:setTouchPriority()
     PRINT_DEPRECATED("Node.setTouchPriority() is deprecated, remove it")
 end
+
+function Node:setCascadeOpacityEnabledRecursively(enabled)
+    self:setCascadeOpacityEnabled(enabled)
+
+    local children = self:getChildren()
+    local childCount = self:getChildrenCount()
+    if childCount < 1 then
+        return
+    end
+    if type(children) == "table" then
+        for i = 1, childCount do
+            local node = children[i]
+            node:setCascadeOpacityEnabledRecursively(enabled)
+        end
+    elseif type(children) == "userdata" then
+        for i = 1, childCount do
+            local node = children:objectAtIndex(i - 1)
+            node:setCascadeOpacityEnabledRecursively(enabled)
+        end
+    end
+end


### PR DESCRIPTION
通过uiloader加载的界面，不能使用setOpacity的接口，原因是CascadeOpacityEnabled没有正确的设置。而CCNode里的setCascadeOpacityEnabled接口只设置节点本身，并没有设置子节点，所以这里添加接口可以递归设置所有节点。
