### PR TITLE
Disable deprecation for android.

### DIFF
--- a/template/PROJECT_TEMPLATE_01/proj.android/jni/Application.mk
+++ b/template/PROJECT_TEMPLATE_01/proj.android/jni/Application.mk
@@ -1,5 +1,5 @@
 APP_STL := gnustl_static
-APP_CPPFLAGS := -frtti -std=c++11 -Wno-error=format-security -Wno-literal-suffix -fsigned-char -Os $(CPPFLAGS)
+APP_CPPFLAGS := -frtti -std=c++11 -Wno-error=format-security -Wno-literal-suffix -Wno-deprecated-declarations -fsigned-char -Os $(CPPFLAGS)
 APP_DEBUG := $(strip $(NDK_DEBUG))
 ifeq ($(APP_DEBUG),1)
   APP_CPPFLAGS += -DCOCOS2D_DEBUG=1


### PR DESCRIPTION
cocos2d-x 3.x has marked some classes and methods as deprecated.
This cause a lot of warnings when build android.

So add `-Wno-deprecated-declarations` flags.
