### PR TITLE
ignore source file path

### DIFF
--- a/lib/cocos2d-x/scripting/lua/lua/lua-5.1.5/src/ldump.c
+++ b/lib/cocos2d-x/scripting/lua/lua/lua-5.1.5/src/ldump.c
@@ -129,7 +129,7 @@ static void DumpDebug(const Proto* f, DumpState* D)
 
 static void DumpFunction(const Proto* f, const TString* p, DumpState* D)
 {
- DumpString((f->source==p || D->strip) ? NULL : f->source,D);
+ DumpString(NULL,D);
  DumpInt(f->linedefined,D);
  DumpInt(f->lastlinedefined,D);
  DumpChar(f->nups,D);


### PR DESCRIPTION
使用luac编译两内容一样的、hash值一致的lua源文件，会因为源文件的路径不同，而得到两个hash值不一致的输出文件。这样不利于多人多机器协同开发。
