### PR TITLE
bug fix

### DIFF
--- a/lib/cocos2d-x/external/extra/apptools/HelperFunc.cpp
+++ b/lib/cocos2d-x/external/extra/apptools/HelperFunc.cpp
@@ -13,37 +13,36 @@ unsigned char* CZHelperFunc::getFileData(const char* pszFileName, const char* ps
 {
     unsigned long size;
     unsigned char* buf = CCFileUtils::sharedFileUtils()->getFileData(pszFileName, pszMode, &size);
-    if (NULL==buf || size<1) return NULL;
+    if (NULL==buf) {
+        return NULL;
+    } else if (size < 1) {
+        delete []buf;
+        return NULL;
+    }
     
     CCLuaStack* stack = CCLuaEngine::defaultEngine()->getLuaStack();
-	unsigned char* buffer = NULL;
+    
+	unsigned char* buffer;
+    if (stack && stack->m_xxteaEnabled && size > stack->m_xxteaSignLen && memcmp(buf, stack->m_xxteaSign, stack->m_xxteaSignLen) == 0) {
+        // decrypt XXTEA
+        xxtea_long len = 0;
+        unsigned char * tbuff;
+        tbuff = xxtea_decrypt(buf + stack->m_xxteaSignLen,
+                               (xxtea_long)size - (xxtea_long)stack->m_xxteaSignLen,
+                               (unsigned char*)stack->m_xxteaKey,
+                               (xxtea_long)stack->m_xxteaKeyLen,
+                               &len);
+        delete []buf;
+        buffer = new unsigned char[len];
+        memcpy(buffer, tbuff, len);
+        free(tbuff);
+		size = len;
+    } else {
+		buffer = buf;
+    }
 
-        bool isXXTEA = stack && stack->m_xxteaEnabled;
-        for (unsigned int i = 0; isXXTEA && ((int)i) < stack->m_xxteaSignLen && i < size; ++i)
-        {
-            isXXTEA = buf[i] == stack->m_xxteaSign[i];
-        }
-
-        if (isXXTEA)
-        {
-            // decrypt XXTEA
-            xxtea_long len = 0;
-            buffer = xxtea_decrypt(buf + stack->m_xxteaSignLen,
-                                   (xxtea_long)size - (xxtea_long)stack->m_xxteaSignLen,
-                                   (unsigned char*)stack->m_xxteaKey,
-                                   (xxtea_long)stack->m_xxteaKeyLen,
-                                   &len);
-            delete []buf;
-            buf = NULL;
-			size = len;
-        }
-        else
-        {
-			buffer = buf;
-        }
-
-		if (pSize) *pSize = size;
-		return buffer;
+	if (pSize) *pSize = size;
+	return buffer;
 }
 
 int CZHelperFunc::getFileData(const char *pPathFile)
@@ -54,7 +53,7 @@ int CZHelperFunc::getFileData(const char *pPathFile)
     
     CCLuaStack* stack = CCLuaEngine::defaultEngine()->getLuaStack();
 	stack->clean();
-    stack->pushString((const char*)(buf), size);
-    delete buf;
+    stack->pushString((const char*)buf, size);
+    delete []buf;
     return 1;
 }


### PR DESCRIPTION
fix:
delete with memory allocated by malloc() or new [];
improve a compare for loop with memcpy();
修复一个bug: 当文件的内容与xxtea签名一致时, 长度小于签名时, 原来的代码会误判断为加密文件,从而在后面的处理中 buf + 签名长度 内存越界;