### PR TITLE
Fixed not allow access data on code not equal 200

### DIFF
--- a/lib/cocos2d-x/cocos2dx/platform/android/java/src/org/cocos2dx/lib/QuickHTTPInterface.java
+++ b/lib/cocos2d-x/cocos2dx/platform/android/java/src/org/cocos2dx/lib/QuickHTTPInterface.java
@@ -325,8 +325,15 @@ public class QuickHTTPInterface {
 
     static byte[] getResponedString(HttpURLConnection http) {
         try {
-            DataInputStream in = new DataInputStream(http.getInputStream());
-
+            int statusCode = http.getResponseCode(); 
+            
+            DataInputStream in = null;
+            if(statusCode != 200 && statusCode != 201) {
+                in = new DataInputStream(http.getErrorStream());
+            }else{
+                in = new DataInputStream(http.getInputStream());
+            }
+                        
             byte[] buffer = new byte[1024];
             byte[] retBuf = null;
             int len = in.read(buffer);

--- a/lib/cocos2d-x/external/extra/platform/android/CCHTTPRequestAndroid.cpp
+++ b/lib/cocos2d-x/external/extra/platform/android/CCHTTPRequestAndroid.cpp
@@ -606,7 +606,7 @@ void CCHTTPRequest::onRequest(void)
     m_errorCode = code;
     m_responseCode = code;
     m_errorMessage = (code >= 200 && code < 300) ? "" : getResponedErrJava();
-    m_state = (code == 200) ? kCCHTTPRequestStateCompleted : kCCHTTPRequestStateFailed;
+    m_state = (code >= 200 && code < 600) ? kCCHTTPRequestStateCompleted : kCCHTTPRequestStateFailed;
     m_curlState = kCCHTTPRequestCURLStateClosed;
 }
 


### PR DESCRIPTION
android http 客户端在status code 不是200时,不能获取status code和body

http://stackoverflow.com/questions/9129766/urlconnection-is-not-allowing-me-to-access-data-on-http-errors-404-500-etc
